### PR TITLE
remove the gitProjectID as it causes issues in the UpdateCenter json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,16 @@ the License.
   <properties>
     <java.level>7</java.level>
     <jenkins.version>1.596.1</jenkins.version>
-    <project.gitProjectId>
-      google-deployment-manager-plugin
-    </project.gitProjectId>
   </properties>
 
   <scm>
     <connection>
-      scm:git:git://github.com/jenkinsci/${project.gitProjectId}.git
+      scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git
     </connection>
     <developerConnection>
-      scm:git:git@github.com:jenkinsci/${project.gitProjectId}.git
+      scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git
     </developerConnection>
-    <url>http://github.com/jenkinsci/${project.gitProjectId}</url>
+    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
the SCM url is not interpolated in the update center json.
also there is no real need for this to be changeable from the command line as the organisation is hard coded).  so just switch back to the good old way of doing things.